### PR TITLE
Add 20201.MeasurementAux for optical flow diagnostics

### DIFF
--- a/com/ark/equipment/flow/20201.MeasurementAux.uavcan
+++ b/com/ark/equipment/flow/20201.MeasurementAux.uavcan
@@ -14,11 +14,11 @@ uint24 shutter             # Exposure integration time, sensor clocks.
 
 uint2 illumination_mode    # 0 = bright, 1 = low-light,
                            # 2 = super-low-light, 3 = unknown.
-uint1 motion               # 1 = motion bit set in this frame.
-uint1 challenging_surface  # 1 = striped / checkerboard / glossy surface.
+bool  motion               # 1 = motion bit set in this frame.
+bool  challenging_surface  # 1 = striped / checkerboard / glossy surface.
                            # PAA3905: hardware flag (Motion register bit 0).
                            # PAW3902: always 0 (chip has no such flag).
-uint1 chip_health_ok       # 1 = chip self-reported healthy this frame.
+bool  chip_health_ok       # 1 = chip self-reported healthy this frame.
                            # PAA3905: Observation[5:0] == 0x3F.
                            # PAW3902: no unexpected reset since last sample.
 void3                      # reserved, must be zero.

--- a/com/ark/equipment/flow/20201.MeasurementAux.uavcan
+++ b/com/ark/equipment/flow/20201.MeasurementAux.uavcan
@@ -1,0 +1,31 @@
+#
+# Per-sample diagnostics for optical flow sensors.
+#
+# Broadcast alongside com.hex.equipment.flow.Measurement (DTID 20200) at
+# the flow-chip sample rate. Carries fields needed to assess the
+# reliability/confidence of each flow sample that are not representable
+# in the single uint8 `quality` byte of the companion message.
+#
+
+uint24 shutter             # Exposure integration time, sensor clocks.
+                           # Right-justified: PAA3905 uses the full 23-bit
+                           # value, PAW3902 uses the low 13 bits.
+                           # 0xFFFFFF = invalid.
+
+uint2 illumination_mode    # 0 = bright, 1 = low-light,
+                           # 2 = super-low-light, 3 = unknown.
+uint1 motion               # 1 = motion bit set in this frame.
+uint1 challenging_surface  # 1 = striped / checkerboard / glossy surface.
+                           # PAA3905: hardware flag (Motion register bit 0).
+                           # PAW3902: always 0 (chip has no such flag).
+uint1 chip_health_ok       # 1 = chip self-reported healthy this frame.
+                           # PAA3905: Observation[5:0] == 0x3F.
+                           # PAW3902: no unexpected reset since last sample.
+void3                      # reserved, must be zero.
+
+uint16 discard_count       # Saturating count of frames dropped by the
+                           # driver's SQUAL/Shutter false-motion guard
+                           # since boot. Rate of change is the useful
+                           # signal; absolute value is not.
+uint16 mode_change_count   # Saturating count of illumination-mode
+                           # transitions since boot.


### PR DESCRIPTION
## Summary

Adds `com.ark.equipment.flow.20201.MeasurementAux` — a companion diagnostics message to `com.hex.equipment.flow.20200.Measurement`.

The existing `Measurement` message carries only a single `uint8 quality` byte (typically the PixArt SQUAL register pass-through), which leaves a consumer unable to distinguish between genuine texture-poor surfaces, light-mode saturation, challenging-surface detections (PAA3905 striped/checkerboard/glossy flag), and driver-side false-motion discards. This message exposes those per-sample signals.

Broadcast alongside the 20200 message at the flow-chip sample rate (126 Hz in Bright/LowLight, 50 Hz in SuperLowLight for PAW3902/PAA3905). 8 bytes payload, two CAN 2.0B frames per transfer.

## Fields

- ` uint24 shutter ` — exposure integration time, sensor clocks. PAA3905 uses the full 23-bit value; PAW3902 the low 13 bits. ` 0xFFFFFF ` = invalid.
- ` uint2 illumination_mode ` — 0 bright, 1 low-light, 2 super-low-light, 3 unknown.
- ` bool motion ` — motion bit set in this frame.
- ` bool challenging_surface ` — hardware flag on PAA3905; always 0 on PAW3902.
- ` bool chip_health_ok ` — PAA3905 ` Observation[5:0] == 0x3F `; PAW3902 no unexpected reset since last sample.
- ` void3 ` — reserved.
- ` uint16 discard_count ` — saturating count of frames dropped by the driver's SQUAL/Shutter false-motion guard.
- ` uint16 mode_change_count ` — saturating count of illumination-mode transitions.

## DTID

20201, chosen as the immediate sibling of `com.hex.equipment.flow.20200.Measurement` so the pairing is obvious in any DTID registry listing. Free in the current tree (nearest occupied slots are 20200 and 20300).

## Status

Draft — pairs with the companion PX4 PR on the dakejahl fork that populates and broadcasts this message from the PAW3902 / PAA3905 drivers and the ARK Flow / ARK Flow MR CAN-node firmware.